### PR TITLE
Add earliest time check for wake_focus sessions

### DIFF
--- a/scripts/wake_focus_sync.py
+++ b/scripts/wake_focus_sync.py
@@ -50,6 +50,8 @@ WAKEANDFOCUS_GOAL = "wakeandfocus"
 
 LOCAL_TZ = ZoneInfo("America/New_York")
 MIN_SESSION_MINUTES = 50
+EARLIEST_HOUR = 6
+EARLIEST_MINUTE = 0
 CUTOFF_HOUR = 9
 CUTOFF_MINUTE = 15  # inclusive
 
@@ -103,7 +105,10 @@ def parse_comment_for_length_and_time(comment: Optional[str]):
     return minutes, hour, minute
 
 def qualifies_time(hour: int, minute: int) -> bool:
-    return (hour < CUTOFF_HOUR) or (hour == CUTOFF_HOUR and minute <= CUTOFF_MINUTE)
+    return (
+        (hour > EARLIEST_HOUR or (hour == EARLIEST_HOUR and minute >= EARLIEST_MINUTE))
+        and ((hour < CUTOFF_HOUR) or (hour == CUTOFF_HOUR and minute <= CUTOFF_MINUTE))
+    )
 
 def now_iso_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/test_qualifies_time.py
+++ b/tests/test_qualifies_time.py
@@ -1,0 +1,16 @@
+import importlib.util
+from pathlib import Path
+
+# Load the wake_focus_sync module directly from its file path
+spec = importlib.util.spec_from_file_location(
+    "wake_focus_sync", Path(__file__).resolve().parents[1] / "scripts" / "wake_focus_sync.py"
+)
+wf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(wf)
+
+
+def test_qualifies_time_boundaries():
+    assert not wf.qualifies_time(5, 59)
+    assert wf.qualifies_time(6, 0)
+    assert wf.qualifies_time(9, 15)
+    assert not wf.qualifies_time(9, 16)


### PR DESCRIPTION
## Summary
- define `EARLIEST_HOUR` and `EARLIEST_MINUTE` constants
- require session times to fall between earliest and cutoff bounds
- test time qualification boundaries around 6:00 and 9:15

## Testing
- `python -m py_compile scripts/wake_focus_sync.py`
- `pytest tests/test_qualifies_time.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ceac3ecc83269e490a94e0e6904e